### PR TITLE
Moved --org into individual commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ repos: 78
 You can specify a GitHub org name for all commands, including `org info`.
 
 ```
-./bin/project --org aws org info
+./bin/project org info --org=aws
 ```
 
 #### Org Members
@@ -103,7 +103,7 @@ You can specify relative dates.
 For large organizations the default paging interval of 7 days may be too big and fail with `error: There are 1000+ PRs returned from a single query for 7 day(s), reduce --page.`. Decrease the page size.
 
 ```
-./bin/project --org aws contributors stats --page 3
+./bin/project contributors stats --org=aws --page 3
 ```
 
 #### Contributor Lists
@@ -121,13 +121,13 @@ sbcd90
 Specify org and repo.
 
 ```
-./bin/project --org aws contributors list --repo aws-cli
+./bin/project contributors list --repo=aws-cli --org=aws
 ```
 
 Specify multiple repos.
 
 ```
-./bin/project --org aws contributors list --repo aws-cli --repo deep-learning-containers
+./bin/project contributors list --org=aws --repo=aws-cli --repo=deep-learning-containers
 ```
 
 #### Pull Requests
@@ -135,7 +135,7 @@ Specify multiple repos.
 Show a list of pull requests.
 
 ```
-./bin/project --org aws prs list --repo aws-cli
+./bin/project prs list --org=aws --repo=aws-cli
 ```
 
 #### Pull Request Stats
@@ -166,13 +166,13 @@ Get the stats since the beginning of year till today.
 Get the stats for a given repo for last week.
 
 ```
-./bin/project --org aws prs stats --repo aws-cli
+./bin/project prs stats --org=aws --repo aws-cli
 ```
 
 Get the stats for multiple repos.
 
 ```
-./bin/project --org aws prs stats --repo aws-cli --repo deep-learning-containers
+./bin/project prs stats --org=aws --repo=aws-cli --repo=deep-learning-containers
 ```
 
 #### Issues
@@ -196,7 +196,7 @@ autocut: 6
 Specify org and repo.
 
 ```
-./bin/project --org aws issues labels --repo aws-cli
+./bin/project issues labels --org=aws --repo=aws-cli
 ```
 
 By default returns stats for the last full week. Specify `from` and `to` for different dates.

--- a/bin/commands/contributors.rb
+++ b/bin/commands/contributors.rb
@@ -2,24 +2,27 @@
 
 desc 'Data about contributors.'
 command 'contributors' do |g|
-  g.flag [:page], desc: 'Size of page in days.', default_value: 7, type: Integer
-  g.flag [:from], desc: 'Start at.', default_value: Date.today.beginning_of_week.last_week
-  g.flag [:to], desc: 'End at.', default_value: Date.today.beginning_of_week - 1
-  g.flag [:repo], multiple: true, desc: 'Search a specific repo within the org.'
+  g.flag %i[page], desc: 'Size of page in days.', default_value: 7, type: Integer
+  g.flag %i[from], desc: 'Start at.', default_value: Date.today.beginning_of_week.last_week
+  g.flag %i[to], desc: 'End at.', default_value: Date.today.beginning_of_week - 1
+  g.flag %i[o org], desc: 'Name of the GitHub organization.', default_value: 'opensearch-project'
+  g.flag %i[repo], multiple: true, desc: 'Search a specific repo within the org.'
 
-  g.desc 'Operate on a set of contributors.'
+  g.desc 'List contributors.'
   g.command 'list' do |c|
     c.action do |_global_options, options, _args|
-      $org.pull_requests(options).contributors.humans.sort.uniq.each do |pr|
+      org = GitHub::Organization.new(options['org'])
+      org.pull_requests(options).contributors.humans.sort.uniq.each do |pr|
         puts pr
       end
     end
   end
 
-  g.desc 'Contributor stats.'
+  g.desc 'Show contributor stats.'
   g.command 'stats' do |c|
     c.action do |_global_options, options, _args|
-      buckets = $org.pull_requests(options).contributors.buckets
+      org = GitHub::Organization.new(options['org'])
+      buckets = org.pull_requests(options).contributors.buckets
       puts "total = #{buckets.values.map(&:size).sum}"
       buckets.each_pair do |bucket, logins|
         puts "#{bucket} (#{logins.size}):"

--- a/bin/commands/issues.rb
+++ b/bin/commands/issues.rb
@@ -2,24 +2,27 @@
 
 desc 'Data on GitHub issues.'
 command 'issue', 'issues' do |g|
-  g.flag [:page], desc: 'Size of page in days.', default_value: 7, type: Integer
-  g.flag [:from], desc: 'Start at.', default_value: Date.today.beginning_of_week.last_week
-  g.flag [:to], desc: 'End at.', default_value: Date.today.beginning_of_week - 1
-  g.flag [:repo], multiple: true, desc: 'Search a specific repo within the org.'
+  g.flag %i[page], desc: 'Size of page in days.', default_value: 7, type: Integer
+  g.flag %i[from], desc: 'Start at.', default_value: Date.today.beginning_of_week.last_week
+  g.flag %i[to], desc: 'End at.', default_value: Date.today.beginning_of_week - 1
+  g.flag %i[o org], desc: 'Name of the GitHub organization.', default_value: 'opensearch-project'
+  g.flag %i[repo], multiple: true, desc: 'Search a specific repo within the org.'
 
-  g.desc 'Lists issue stats in the organization.'
+  g.desc 'List issue stats in the organization.'
   g.command 'labels' do |c|
     c.action do |_global_options, options, _args|
-      $org.issues(options).labels.sort.each do |label, issues|
+      org = GitHub::Organization.new(options['org'])
+      org.issues(options).labels.sort.each do |label, issues|
         puts "#{label}: #{issues.count}"
       end
     end
   end
 
-  g.desc 'Finds oldest untriaged offenders.'
+  g.desc 'Find oldest untriaged offenders.'
   g.command 'untriaged' do |c|
     c.action do |_global_options, options, _args|
-      untriaged_issues = $org.issues(options.merge(label: 'untriaged'))
+      org = GitHub::Organization.new(options['org'])
+      untriaged_issues = org.issues(options.merge(label: 'untriaged'))
       puts "There are #{untriaged_issues.count} untriaged issues created between #{Chronic.parse(options[:from]).to_date} and #{Chronic.parse(options[:to]).to_date}."
       puts "\n# By Repo\n"
       untriaged_issues.repos.each_pair do |repo, issues|
@@ -33,10 +36,11 @@ command 'issue', 'issues' do |g|
     end
   end
 
-  g.desc 'Finds labelled for incorrect release.'
+  g.desc 'Find issues labelled for releases.'
   g.command 'released' do |c|
     c.action do |_global_options, options, _args|
-      issues = $org.issues(options)
+      org = GitHub::Organization.new(options['org'])
+      issues = org.issues(options)
       puts "# Label Counts\n"
       issues.version_labels.sort.each do |label, issues|
         puts "#{label}: #{issues.count}"

--- a/bin/commands/org.rb
+++ b/bin/commands/org.rb
@@ -2,19 +2,24 @@
 
 desc 'Data about a GitHub organization.'
 command 'org' do |g|
-  g.desc 'Provides basic information about the GitHub organization.'
+  g.flag %i[o org], desc: 'Name of the GitHub organization.', default_value: 'opensearch-project'
+
+  g.desc 'Show information about a GitHub organization.'
   g.command 'info' do |c|
-    c.action do |_global_options, _options, _args|
-      puts $org.info
+    c.action do |_global_options, options, _args|
+      org = GitHub::Organization.new(options['org'])
+      puts org.info
     end
   end
 
+  g.desc 'Compare GitHub org members to lists of members in data files.'
   g.command 'members' do |c|
-    c.action do |_global_options, _options, _args|
-      puts "org: #{$org.name}"
-      puts "members: #{$org.members.count}"
-      puts "missing in data/users/members.txt: #{($org.members.logins - GitHub::Data.members).join(' ')}"
-      puts "no longer members: #{(GitHub::Data.members - $org.members.logins).join(' ')}"
+    c.action do |_global_options, options, _args|
+      org = GitHub::Organization.new(options['org'])
+      puts "org: #{org.name}"
+      puts "members: #{org.members.count}"
+      puts "missing in data/users/members.txt: #{(org.members.logins - GitHub::Data.members).join(' ')}"
+      puts "no longer members: #{(GitHub::Data.members - org.members.logins).join(' ')}"
     end
   end
 end

--- a/bin/commands/pr.rb
+++ b/bin/commands/pr.rb
@@ -2,25 +2,28 @@
 
 desc 'Data on GitHub pull requests.'
 command 'pr', 'prs' do |g|
-  g.flag [:page], desc: 'Size of page in days.', default_value: 7, type: Integer
-  g.flag [:from], desc: 'Start at.', default_value: Date.today.beginning_of_week.last_week
-  g.flag [:to], desc: 'End at.', default_value: Date.today.beginning_of_week - 1
-  g.flag [:repo], multiple: true, desc: 'Search a specific repo within the org.'
+  g.flag %i[page], desc: 'Size of page in days.', default_value: 7, type: Integer
+  g.flag %i[from], desc: 'Start at.', default_value: Date.today.beginning_of_week.last_week
+  g.flag %i[to], desc: 'End at.', default_value: Date.today.beginning_of_week - 1
+  g.flag %i[o org], desc: 'Name of the GitHub organization.', default_value: 'opensearch-project'
+  g.flag %i[repo], multiple: true, desc: 'Search a specific repo within the org.'
   g.switch %i[ignore-unknown], desc: 'Ignore unknown users.', default_value: false
 
-  g.desc 'Lists pull requests in the organization.'
+  g.desc 'List pull requests in the organization.'
   g.command 'list' do |c|
     c.action do |_global_options, options, _args|
-      $org.pull_requests(options).each do |pr|
+      org = GitHub::Organization.new(options['org'])
+      org.pull_requests(options).each do |pr|
         puts pr
       end
     end
   end
 
-  g.desc 'Pull request stats.'
+  g.desc 'Show pull request stats.'
   g.command 'stats' do |c|
     c.action do |_global_options, options, _args|
-      prs = $org.pull_requests(options)
+      org = GitHub::Organization.new(options['org'])
+      prs = org.pull_requests(options)
       if !options['ignore-unknown'] && prs.contributors[:unknown]&.any?
         puts 'Add the following users to either data/users/members.txt, external.txt or contractors.txt and re-run.'
         prs.contributors[:unknown].keys.take(10).each do |user|

--- a/bin/commands/repos.rb
+++ b/bin/commands/repos.rb
@@ -2,10 +2,13 @@
 
 desc 'Repos.'
 command 'repos' do |g|
-  g.desc 'Lists repos in the organization.'
+  g.flag %i[o org], desc: 'Name of the GitHub organization.', default_value: 'opensearch-project'
+
+  g.desc 'List repos in the GitHub organization.'
   g.command 'list' do |c|
     c.action do |_global_options, _options, _args|
-      $org.repos.sort_by(&:name).each do |repo|
+      org = GitHub::Organization.new(options['org'])
+      org.repos.sort_by(&:name).each do |repo|
         puts repo.name
       end
     end

--- a/bin/project
+++ b/bin/project
@@ -14,7 +14,6 @@ switch %i[d debug], desc: 'Enable debug-level logging.', default_value: false
 switch %i[no-cache], desc: 'Disable local cache (.cache).', default_value: false
 switch %i[q quiet], desc: "Don't show progress bars.", default_value: false
 
-flag %i[o org], desc: 'Name of the GitHub organization.', default_value: 'opensearch-project'
 flag %i[t token], desc: 'Optional GitHub token.', default_value: ENV.fetch('GITHUB_API_TOKEN', nil)
 flag %i[vcr-cassette-name], desc: 'Offline VCR cassette.'
 
@@ -58,7 +57,6 @@ pre do |global_options, _command, _options, _args|
   end
 
   $github = Octokit::Client.new(client_options)
-  $org = GitHub::Organization.new(global_options['org'])
 
   ENV['GLI_DEBUG'] = 'true' if global_options['debug']
 

--- a/spec/project/commands/contributors_spec.rb
+++ b/spec/project/commands/contributors_spec.rb
@@ -5,12 +5,12 @@ describe 'project contributors' do
 
   context 'stats' do
     it 'returns contributors' do
-      output = `"#{project}" --no-cache --vcr-cassette-name=search/RedHatOfficial/issues_2022-01-01_2022-01-06 --org RedHatOfficial contributors stats --from=2022-01-01 --to=2022-01-06`.strip
+      output = `"#{project}" --no-cache --vcr-cassette-name=search/RedHatOfficial/issues_2022-01-01_2022-01-06 contributors stats --org=RedHatOfficial --from=2022-01-01 --to=2022-01-06`.strip
       expect(output).to include 'https://github.com/KushalBeniwal: 1'
     end
 
     it 'parses date' do
-      output = `"#{project}" --no-cache --vcr-cassette-name=search/RedHatOfficial/issues_2022-01-01_2022-01-06 --org RedHatOfficial contributors stats --from=2022-01-01 --to="january sixth 2022"`.strip
+      output = `"#{project}" --no-cache --vcr-cassette-name=search/RedHatOfficial/issues_2022-01-01_2022-01-06 contributors stats --org=RedHatOfficial --from=2022-01-01 --to="january sixth 2022"`.strip
       expect(output).to include 'https://github.com/KushalBeniwal: 1'
     end
   end

--- a/spec/project/commands/org_spec.rb
+++ b/spec/project/commands/org_spec.rb
@@ -4,7 +4,7 @@ describe 'project org' do
   include_context 'command line'
 
   it 'info' do
-    expect(`"#{project}" --no-cache --vcr-cassette-name=orgs/RedHatOfficial --org RedHatOfficial org info`.strip).to eq [
+    expect(`"#{project}" --no-cache --vcr-cassette-name=orgs/RedHatOfficial org info --org=RedHatOfficial`.strip).to eq [
       'name: Red Hat',
       'description: The official GitHub account for Red Hat (VCR).',
       'url: https://api.github.com/orgs/RedHatOfficial',
@@ -23,7 +23,7 @@ describe 'project org' do
     end
 
     it 'members' do
-      expect(`"#{project}" --no-cache --vcr-cassette-name=users/RedHatOfficial --org RedHatOfficial org members`.strip).to eq [
+      expect(`"#{project}" --no-cache --vcr-cassette-name=users/RedHatOfficial org members --org=RedHatOfficial`.strip).to eq [
         'org: RedHatOfficial',
         'members: 6',
         'missing in data/users/members.txt: vcr dmc5179 eschabell Fryguy starryeyez024 suehle',

--- a/spec/project/commands/pr_spec.rb
+++ b/spec/project/commands/pr_spec.rb
@@ -5,12 +5,12 @@ describe 'project pr' do
 
   context 'stats' do
     it 'returns contributors' do
-      output = `"#{project}" --no-cache --vcr-cassette-name=search/RedHatOfficial/prs_2022-01-01_2022-01-06 --org RedHatOfficial prs stats --from=2022-01-01 --to=2022-01-06 --ignore-unknown`.strip
+      output = `"#{project}" --no-cache --vcr-cassette-name=search/RedHatOfficial/prs_2022-01-01_2022-01-06 prs stats --org=RedHatOfficial --from=2022-01-01 --to=2022-01-06 --ignore-unknown`.strip
       expect(output).to include 'Between 2022-01-01 and 2022-01-06, 0% of contributions (0/1) were made by 0 external contributors (0/1).'
     end
 
     it 'parses dates' do
-      output = `"#{project}" --no-cache --vcr-cassette-name=search/RedHatOfficial/prs_2022-01-01_2022-01-06 --org RedHatOfficial prs stats --from=2022-01-01 --to="january sixth 2022" --ignore-unknown`.strip
+      output = `"#{project}" --no-cache --vcr-cassette-name=search/RedHatOfficial/prs_2022-01-01_2022-01-06 prs stats --org=RedHatOfficial --from=2022-01-01 --to="january sixth 2022" --ignore-unknown`.strip
       expect(output).to include 'Between 2022-01-01 and 2022-01-06, 0% of contributions (0/1) were made by 0 external contributors (0/1).'
     end
   end

--- a/spec/support/github.rb
+++ b/spec/support/github.rb
@@ -1,4 +1,3 @@
 Octokit.auto_paginate = true
 GitHub::Progress.enabled = false
 $github = Octokit::Client.new
-$org = GitHub::Organization.new('RedHatOfficial')


### PR DESCRIPTION
Signed-off-by: Daniel (dB.) Doubrovkine <dblock@amazon.com>

### Description

In preparation for https://github.com/opensearch-project/project-tools/issues/20 make orgs configurable per command vs. globally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
