### PR TITLE
Properly exclude bot contributions in PR stats.

### DIFF
--- a/bin/commands/pr.rb
+++ b/bin/commands/pr.rb
@@ -34,12 +34,14 @@ module Bin
               system "open https://github.com/#{user}"
             end
           else
-            puts "Between #{Chronic.parse(options[:from]).to_date} and #{Chronic.parse(options[:to]).to_date}, #{prs.all_external_percent}% of contributions (#{prs.all_external.size}/#{prs.size}) were made by #{prs.contributors.all_external.size} external contributors (#{prs.contributors.all_external.size}/#{prs.contributors.humans.uniq.size})."
+            puts "Between #{Chronic.parse(options[:from]).to_date} and #{Chronic.parse(options[:to]).to_date}, #{prs.all_external_percent}% of contributions (#{prs.all_external.size}/#{prs.all_humans.size}) were made by #{prs.contributors.all_external.size} external contributors (#{prs.contributors.all_external.size}/#{prs.contributors.humans.uniq.size})."
             puts ''
             prs.percent.each_pair do |k, v|
+              next if k == :bots
+
               puts "#{k}: #{v}% (#{prs.buckets[k].size})"
             end
-            if prs[:external]&.size&.< 25
+            if prs[:external]&.size&.< 100
               puts ''
               prs[:external]&.each do |pr|
                 puts pr

--- a/lib/github/buckets.rb
+++ b/lib/github/buckets.rb
@@ -22,8 +22,16 @@ module GitHub
       buckets[:unknown] || []
     end
 
+    def bots
+      buckets[:bots] || []
+    end
+
     def all
       to_a
+    end
+
+    def all_humans
+      all.to_a - bots.to_a
     end
 
     def all_members
@@ -37,12 +45,12 @@ module GitHub
     def all_external_percent
       return 0 unless all.any?
 
-      ((all_external.size.to_f / all.size) * 100).to_i
+      ((all_external.size.to_f / all_humans.size) * 100).to_i
     end
 
     def percent
       buckets.map do |k, v|
-        pc = ((v.size.to_f / all.size) * 100).round(1)
+        pc = ((v.size.to_f / all_humans.size) * 100).round(1)
         [k, pc]
       end.to_h
     end
@@ -56,6 +64,8 @@ module GitHub
         :students
       elsif GitHub::Data.external_users.include?(username.to_s)
         :external
+      elsif GitHub::Data.bots.include?(username.to_s)
+        :bots
       else
         :unknown
       end

--- a/lib/github/contributors.rb
+++ b/lib/github/contributors.rb
@@ -26,6 +26,8 @@ module GitHub
         :students
       elsif GitHub::Data.external_users.include?(username.to_s)
         :external
+      elsif GitHub::Data.bots.include?(username.to_s)
+        :bots
       else
         :unknown
       end


### PR DESCRIPTION
### Description

Properly exclude bot contributions in PR stats.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
