### PR TITLE
Don't make maintainers globally unique.

### DIFF
--- a/lib/github/buckets.rb
+++ b/lib/github/buckets.rb
@@ -51,7 +51,7 @@ module GitHub
     def all_external_percent
       return 0 unless all.any?
 
-      ((all_external.size.to_f / all_humans.size) * 100).to_i
+      ((all_external.size.to_f / all_humans.size) * 100).round(1)
     end
 
     def percent

--- a/lib/github/maintainers.rb
+++ b/lib/github/maintainers.rb
@@ -21,13 +21,13 @@ module GitHub
     def all_external
       ALL_EXTERNAL.map do |bucket|
         buckets[bucket]
-      end.flatten.compact.uniq
+      end.flatten.compact
     end
 
     def all_external_unique_percent
       return 0 unless unique_count
 
-      ((all_external_unique_count.to_f / unique_count) * 100).to_i
+      ((all_external_unique_count.to_f / unique_count) * 100).round(1)
     end
 
     def unique_count

--- a/lib/github/repos.rb
+++ b/lib/github/repos.rb
@@ -19,11 +19,11 @@ module GitHub
 
     def maintainers(dt = nil)
       @maintainers ||= begin
-        all = Set.new
+        all = []
         each do |repo|
           maintainers = repo.maintainers(dt)
           maintainers&.each do |user|
-            all.add(user)
+            all << user
           end
         end
         GitHub::Maintainers.new(all.to_a)
@@ -66,7 +66,7 @@ module GitHub
     def all_external_maintainers_percent
       return 0 unless any?
 
-      (all_external_maintained_size.to_f * 100 / size).to_i
+      (all_external_maintained_size.to_f * 100 / size).round(1)
     end
   end
 end

--- a/spec/project/commands/pr_spec.rb
+++ b/spec/project/commands/pr_spec.rb
@@ -7,22 +7,22 @@ describe 'project pr' do
   context 'stats' do
     it 'returns contributors' do
       output = `"#{project}" --no-cache --vcr-cassette-name=search/RedHatOfficial/prs_2022-01-01_2022-01-06 prs stats --org=RedHatOfficial --from=2022-01-01 --to=2022-01-06 --ignore-unknown`.strip
-      expect(output).to include 'Between 2022-01-01 and 2022-01-06, 0% of contributions (0/1) were made by 0 external contributors (0/1).'
+      expect(output).to include 'Between 2022-01-01 and 2022-01-06, 0.0% of contributions (0/1) were made by 0 external contributors (0/1).'
     end
 
     it 'parses dates' do
       output = `"#{project}" --no-cache --vcr-cassette-name=search/RedHatOfficial/prs_2022-01-01_2022-01-06 prs stats --org=RedHatOfficial --from=2022-01-01 --to="january sixth 2022" --ignore-unknown`.strip
-      expect(output).to include 'Between 2022-01-01 and 2022-01-06, 0% of contributions (0/1) were made by 0 external contributors (0/1).'
+      expect(output).to include 'Between 2022-01-01 and 2022-01-06, 0.0% of contributions (0/1) were made by 0 external contributors (0/1).'
     end
 
     it 'returns contributors for the default org' do
       output = `"#{project}" --no-cache --vcr-cassette-name=search/opensearch-project/prs_2022-01-01_2022-01-06 prs stats --from=2022-01-01 --to=2022-01-06 --ignore-unknown`.strip
-      expect(output).to include 'Between 2022-01-01 and 2022-01-06, 0% of contributions (0/104) were made by 0 external contributors (0/45).'
+      expect(output).to include 'Between 2022-01-01 and 2022-01-06, 0.0% of contributions (0/104) were made by 0 external contributors (0/45).'
     end
 
     it 'returns contributors for a single repo' do
       output = `"#{project}" --no-cache --vcr-cassette-name=search/aws/aws-cli/prs_2022-10-01_2022-10-24 prs stats --repo=aws/aws-cli --from=2022-10-01 --to=2022-10-24 --ignore-unknown`.strip
-      expect(output).to include 'Between 2022-10-01 and 2022-10-24, 0% of contributions (0/12) were made by 0 external contributors (0/5).'
+      expect(output).to include 'Between 2022-10-01 and 2022-10-24, 0.0% of contributions (0/12) were made by 0 external contributors (0/5).'
     end
   end
 end


### PR DESCRIPTION
### Description

To get the %, don't unique maintainers.

```
$ ./bin/project maintainers stats --repo=opensearch-project/OpenSearch --repo=opensearch-project/OpenSearch-Dashboards --repo=opensearch-project/documentation-website --repo=opensearch-project/ml-commons --repo=opensearch-project/k-NN --repo=opensearch-project/data-prepper --repo=opensearch-project/index-management --repo=opensearch-project/security --repo=opensearch-project/sql --repo=opensearch-project/neural-search
As of 2024-03-29, 10 repos have 140 maintainers, where 9.3% (13/140) are external.
A total of 60.0% (6/10) of repos have at least one of 13 external maintainers.

# External Maintainers
https://github.com/opensearch-project/sql: ["MaxKsyunz", "Yury-Fridlyand", "acarbonetto", "forestmvey", "GumpacG"] (26.3%, 5/19)
https://github.com/opensearch-project/OpenSearch: ["reta"] (3.8%, 1/26)
https://github.com/opensearch-project/documentation-website: ["epugh"] (11.1%, 1/9)
https://github.com/opensearch-project/ml-commons: ["austintlee", "HenryL27", "samuel-oci"] (23.1%, 3/13)
https://github.com/opensearch-project/security: ["reta", "willyborankin"] (22.2%, 2/9)
https://github.com/opensearch-project/OpenSearch-Dashboards: ["curq"] (5.6%, 1/18)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
