### PR TITLE
Fix unique maintainers

### DIFF
--- a/bin/commands/maintainers.rb
+++ b/bin/commands/maintainers.rb
@@ -25,6 +25,11 @@ module Bin
             puts "#{repo.html_url}: #{repo.maintainers.all_external} (#{repo.maintainers.all_external_unique_percent}%, #{repo.maintainers.all_external_unique_count}/#{repo.maintainers.unique_count})"
           end
 
+          puts "\n# External Maintainers (Repos)\n"
+          repos.external_maintainers.each_pair do |maintainer, repos_maintained|
+            puts "#{maintainer}: #{repos_maintained.map(&:html_url).join(', ')}"
+          end
+
           # GitHub::Maintainers::ALL_EXTERNAL.each do |bucket|
           #   repos.maintained[bucket]&.sort_by(&:name)&.each do |repo|
           #     puts "#{repo.html_url}: #{repo.maintainers.all_external} (#{repo.maintainers.all_external_unique_percent}%, #{repo.maintainers.all_external_unique_count}/#{repo.maintainers.unique_count})"

--- a/lib/github/maintainers.rb
+++ b/lib/github/maintainers.rb
@@ -21,7 +21,7 @@ module GitHub
     def all_external
       ALL_EXTERNAL.map do |bucket|
         buckets[bucket]
-      end.flatten.compact
+      end.flatten.uniq.compact
     end
 
     def all_external_unique_percent
@@ -31,13 +31,13 @@ module GitHub
     end
 
     def unique_count
-      buckets.values.map(&:size).sum
+      buckets.values.flatten.uniq.size
     end
 
     def all_external_unique_count
       ALL_EXTERNAL.map do |bucket|
-        buckets[bucket]&.size || 0
-      end.sum
+        buckets[bucket]
+      end.compact.flatten.uniq.size
     end
 
     def each_pair(&_block)

--- a/lib/github/repos.rb
+++ b/lib/github/repos.rb
@@ -57,6 +57,19 @@ module GitHub
       end
     end
 
+    def external_maintainers
+      @external_maintainers ||= begin
+        all = {}
+        externally_maintained.each do |repo|
+          repo.maintainers.all_external.each do |maintainer|
+            all[maintainer] ||= []
+            all[maintainer] << repo
+          end
+        end
+        all
+      end
+    end
+
     def all_external_maintained_size
       Maintainers::ALL_EXTERNAL.map do |bucket|
         maintained[bucket]&.size || 0


### PR DESCRIPTION
### Description

Before:

```
As of 2024-04-29, 113 repos have 945 maintainers, where 7.0% (66/945) are external.
A total of 32.7% (37/113) of repos have at least one of 66 external maintainers.
```

After:

```
As of 2024-05-01, 113 repos have 245 maintainers, where 15.9% (39/245) are external.
A total of 32.7% (37/113) of repos have at least one of 39 external maintainers.
```

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
