### PR TITLE
Move dblock to emeritus maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dblock
+# No current code owners

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,6 +4,11 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
+| Maintainer | GitHub ID | Affiliation |
+| ---------- | --------- | ----------- |
+
+## Emeritus
+
 | Maintainer         | GitHub ID                           | Affiliation |
 | ------------------ | ----------------------------------- | ----------- |
 | Daniel Doubrovkine | [dblock](https://github.com/dblock) | Independent |


### PR DESCRIPTION
## Summary
- Moved dblock to emeritus maintainers section
- Added emeritus maintainers section to MAINTAINERS.md
- Removed dblock from CODEOWNERS

🤖 Generated with [Claude Code](https://claude.com/claude-code)